### PR TITLE
Ensure frame_rate is an int before multiplying

### DIFF
--- a/octoprint_webcamstreamer/__init__.py
+++ b/octoprint_webcamstreamer/__init__.py
@@ -172,7 +172,7 @@ class WebcamStreamerPlugin(octoprint.plugin.StartupPlugin,
                 filters.append("transpose=cclock")
             if len(filters) == 0:
                 filters.append("null")
-            gop_size = self._settings.get(["frame_rate"]) * 2
+            gop_size = int(self._settings.get(["frame_rate"])) * 2
             # Substitute vars in ffmpeg command
             docker_cmd = self._settings.get(["ffmpeg_cmd"]).format(
                 webcam_url = self._settings.get(["webcam_url"]),


### PR DESCRIPTION
a framerate of 15 gives a gop_size of "1515" instead of 30

```
Python 2.7.17 (default, Nov  7 2019, 10:07:09)  
>>> print "15"*2
1515
>>> print int("15")*2
30
```


Warning: change is dry-coded in the github web editor